### PR TITLE
Update `phlex-rails` dependency

### DIFF
--- a/nitro_kit.gemspec
+++ b/nitro_kit.gemspec
@@ -27,5 +27,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency("rails", ">= 7.0.0")
   spec.add_dependency("tailwind_merge", ">= 0.13.0")
-  spec.add_dependency("phlex-rails", ">= 2.0.0.beta2")
+  spec.add_dependency("phlex-rails", "~> 2.0.0")
 end


### PR DESCRIPTION
Updating the dependency to `~> 2.0.0`, which will allow for non-breaking changes, e.g. `2.0.1` but not breaking changes, e.g. `2.1.0`.

I ran the tests and clicked around in the app. There didn’t seem to be any issues.