### PR TITLE
Fix missing options when using combobox with field helper in nk_form_for

### DIFF
--- a/app/components/nitro_kit/field.rb
+++ b/app/components/nitro_kit/field.rb
@@ -220,6 +220,7 @@ module NitroKit
     def combobox(**attrs)
       render(
         Combobox.new(
+          options: @options,
           **control_attrs(
             **field_attrs,
             **attrs


### PR DESCRIPTION
### Summary

This PR fixes a bug where options passed to a :combobox field in the nk_form_for helper were not being forwarded correctly to the Combobox component. As a result, the combobox would always render with an empty list of options ([]), making it unusable in form builder contexts.

### Fix

The combobox method in the Field component now explicitly passes the @options instance variable to the Combobox initializer, ensuring the options are rendered properly when using:

```
<div class="my-5">
    <%= form.field :subject, 
      as: :combobox,
      description: "Say hi!!",
      options: [['Hola', '1'], ['Hello', '2'], ['こんにちわ', '3']] %>
  </div>
```

### Notes

This fix does not affect direct use of nk_combobox, which already worked as expected.

### Before

Combobox rendered with no options ([]) when used inside nk_form_for.

```
<ul role="listbox" id="turn_subject-listbox" class="absolute top-0 left-0 p-1 bg-background rounded-md border shadow-sm w-fit max-w-sm flex-col flex z-10 max-h-60 overflow-y-auto data-[state=closed]:hidden [&amp;:not(:has([role=option]))]:hidden [&amp;_[aria-selected]]:bg-muted" data-nk--combobox-target="list" data-state="open" style="left: 430.15625px; top: 521px; width: 241px;">
</ul>
```

### After

Combobox receives and renders the correct options list.

```
<ul role="listbox" id="turn_subject-listbox" class="absolute top-0 left-0 p-1 bg-background rounded-md border shadow-sm w-fit max-w-sm flex-col flex z-10 max-h-60 overflow-y-auto data-[state=closed]:hidden [&amp;:not(:has([role=option]))]:hidden [&amp;_[aria-selected]]:bg-muted" data-nk--combobox-target="list" data-state="closed" style="left: 309.65625px; top: 521px; width: 241px;">
  <li role="option" data-value="1" class="hidden flex-none px-2 py-1 rounded font-medium truncate cursor-pointer hover:bg-muted [&amp;[role=option]]:block">Hola</li>
  <li role="option" data-value="2" class="hidden flex-none px-2 py-1 rounded font-medium truncate cursor-pointer hover:bg-muted [&amp;[role=option]]:block">Hello</li>
  <li role="option" data-value="3" class="hidden flex-none px-2 py-1 rounded font-medium truncate cursor-pointer hover:bg-muted [&amp;[role=option]]:block">こんにちわ</li>
</ul>
```

