### PR TITLE
Keep cached progressive images visible

### DIFF
--- a/app/components/nitro_kit/progressive_image.rb
+++ b/app/components/nitro_kit/progressive_image.rb
@@ -34,7 +34,8 @@ module NitroKit
           aria: { busy: @attached ? true : nil },
           data: {
             state: @attached ? "loading" : "empty",
-            controller: @attached ? "nk--progressive-image" : nil
+            controller: @attached ? "nk--progressive-image" : nil,
+            action: @attached ? "turbo:before-cache@document->nk--progressive-image#prepareForCache" : nil
           }.compact
         },
         html:,

--- a/app/javascript/controllers/nk/progressive_image_controller.js
+++ b/app/javascript/controllers/nk/progressive_image_controller.js
@@ -24,6 +24,10 @@ export default class extends Controller {
     if (this.hasFallbackTarget) this.fallbackTarget.hidden = true;
   }
 
+  prepareForCache() {
+    delete this.element.dataset.enhanced;
+  }
+
   imageTargetConnected(image) {
     if (this.connected) this.bindImage(image);
   }
@@ -47,11 +51,14 @@ export default class extends Controller {
     this.releaseImage();
     this.boundImage = image;
     this.revision = (this.revision || 0) + 1;
-    this.setState("loading");
     image.addEventListener("load", this.onLoad);
     image.addEventListener("error", this.onError);
 
-    if (image.complete) this.reflectComplete(image);
+    if (image.complete) {
+      this.reflectComplete(image);
+    } else {
+      this.setState("loading");
+    }
   }
 
   releaseImage() {
@@ -98,11 +105,8 @@ export default class extends Controller {
   }
 
   reflectComplete(image) {
-    if (image.naturalWidth > 0) {
-      this.loaded();
-    } else {
-      this.failed();
-    }
+    this.revision = (this.revision || 0) + 1;
+    this.setState(image.naturalWidth > 0 ? "loaded" : "error");
   }
 
   setState(state) {

--- a/test/components/progressive_image_controller_contract_test.rb
+++ b/test/components/progressive_image_controller_contract_test.rb
@@ -28,8 +28,11 @@ class ProgressiveImageControllerContractTest < ActiveSupport::TestCase
     assert_includes SOURCE, "fallbackTargetConnected(fallback)"
     assert_includes SOURCE, 'this.setState("loading")'
     assert_includes SOURCE, 'this.setState("empty")'
+    assert_includes SOURCE, "if (image.complete)"
+    assert_includes SOURCE, 'this.setState(image.naturalWidth > 0 ? "loaded" : "error")'
     assert_includes SOURCE, "!this.hasImageTarget"
     assert_includes SOURCE, "revision !== this.revision"
     assert_includes SOURCE, "delete this.element.dataset.enhanced"
+    assert_includes SOURCE, "prepareForCache()"
   end
 end

--- a/test/components/progressive_image_test.rb
+++ b/test/components/progressive_image_test.rb
@@ -51,6 +51,7 @@ class ProgressiveImageTest < ActiveSupport::TestCase
     assert_equal "loading", node["data-state"]
     assert_equal "true", node["aria-busy"]
     assert_equal "nk--progressive-image", node["data-controller"]
+    assert_equal "turbo:before-cache@document->nk--progressive-image#prepareForCache", node["data-action"]
 
     placeholder = node.at_css("[data-slot='progressive-image-placeholder']")
     image = node.at_css("[data-slot='progressive-image-image']")
@@ -94,6 +95,7 @@ class ProgressiveImageTest < ActiveSupport::TestCase
 
     assert_equal "empty", node["data-state"]
     assert_nil node["data-controller"]
+    assert_nil node["data-action"]
     assert_nil node["aria-busy"]
     assert_empty node.css("img")
 

--- a/test/system/former_pro_components_test.rb
+++ b/test/system/former_pro_components_test.rb
@@ -44,6 +44,13 @@ class FormerProComponentsTest < ApplicationSystemTestCase
 
     assert_current_path gallery_component_path("progressive-image")
     assert_selector "#gallery-progressive-image-loaded[data-state='loaded']", count: 1
+    assert_equal "1", evaluate_script(<<~JAVASCRIPT)
+      getComputedStyle(
+        document.querySelector(
+          "#gallery-progressive-image-loaded [data-slot='progressive-image-image']"
+        )
+      ).opacity
+    JAVASCRIPT
     execute_script(
       "arguments[0].scrollIntoView({ block: 'center' })",
       find("#gallery-progressive-image-error")
@@ -89,6 +96,26 @@ class FormerProComponentsTest < ApplicationSystemTestCase
 
     assert_equal "1", visibility.fetch("imageOpacity")
     assert_equal "0", visibility.fetch("placeholderOpacity")
+    assert_no_severe_console_errors(context: path)
+  end
+
+  test "Turbo caches progressive images without transient loading styles" do
+    path = gallery_component_path("progressive-image")
+    visit path
+
+    root = "#gallery-progressive-image-loaded"
+    assert_selector "#{root}[data-state='loaded'][data-enhanced='true']"
+
+    execute_script("document.dispatchEvent(new Event('turbo:before-cache'))")
+
+    assert_selector "#{root}:not([data-enhanced])"
+    opacity = evaluate_script(<<~JAVASCRIPT)
+      getComputedStyle(
+        document.querySelector("#{root} [data-slot='progressive-image-image']")
+      ).opacity
+    JAVASCRIPT
+
+    assert_equal "1", opacity
     assert_no_severe_console_errors(context: path)
   end
 end


### PR DESCRIPTION
## What changed

- Settle already-complete progressive images synchronously on reconnect.
- Remove transient enhanced loading styles before Turbo caches a page.
- Cover Turbo navigation, cache preparation, and component markup contracts.

## Why

Returning to an image collection from another Turbo page reconnected every
progressive image as loading, even when the browser already had a complete
image. The full image became nearly transparent while an unnecessary decode
cycle ran, making cached artwork appear to disappear.

## Validation

- `bin/rails test test/components/progressive_image_test.rb test/components/progressive_image_controller_contract_test.rb`
- `bin/rails test:system test/system/former_pro_components_test.rb`
- Full Nitro system suite: 72 tests, 1,055 assertions; one stale-element test
  flaked under parallel execution and passed immediately in isolation.
